### PR TITLE
fixed column-*.hbs中{{current}}为空的问题

### DIFF
--- a/core/services/categories.service.js
+++ b/core/services/categories.service.js
@@ -139,7 +139,7 @@ exports.navigation = function (options, callback) {
             category.current = false;
           }
 
-          if (category.node) {
+          if (category.nodes) {
             category.nodes = loop(category.nodes);
           }
 


### PR DESCRIPTION
category对象的属性是nodes，不存在node，所以遍历nodes子对象的时候没有遍历到,到前端的current就为空了